### PR TITLE
Switch to hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,12 @@ uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bytes = "0.5.2"
 hyper = { version = "0.13.0", default-features = false, features = ["tcp"] }
+
+[target.'cfg(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))'.dependencies]
 hyper-rustls = "0.19.0"
+
+[target.'cfg(all(not(target_arch = "wasm32"), not(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))))'.dependencies]
+hyper-tls = "0.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bytes = "0.5.2"
 hyper = { version = "0.13.0", default-features = false, features = ["tcp"] }
-hyper-tls = "0.4.0"
+hyper-rustls = "0.19.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.31"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,19 @@ pub struct Client {
     access_token: Option<String>,
 }
 
-impl Client {
-    /// Creates a new client.
-    pub fn new() -> Self {
+impl Default for Client {
+    fn default() -> Self {
         Client {
             client: platform::Client::new(),
             access_token: None,
         }
+    }
+}
+
+impl Client {
+    /// Creates a new client.
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Sets the client's access token, which can be used to authenticate to all API endpoints.

--- a/src/platform/native.rs
+++ b/src/platform/native.rs
@@ -1,6 +1,6 @@
 use bytes::buf::BufExt;
 use http::{Request, Response};
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use std::{io::Read, ops::Deref};
 
 pub use hyper::{Body, Error};

--- a/src/platform/native.rs
+++ b/src/platform/native.rs
@@ -1,6 +1,25 @@
 use bytes::buf::BufExt;
 use http::{Request, Response};
+#[cfg(all(
+    any(target_os = "linux", target_family = "windows", target_os = "macos"),
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+    ),
+))]
 use hyper_rustls::HttpsConnector;
+#[cfg(not(all(
+    any(target_os = "linux", target_family = "windows", target_os = "macos"),
+    any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+    ),
+)))]
+use hyper_tls::HttpsConnector;
 use std::{io::Read, ops::Deref};
 
 pub use hyper::{Body, Error};


### PR DESCRIPTION
By using hyper-rustls we reduce the amount of native dependencies the developers and final users of the application will have to have on their system. However hyper-rustls uses some architecture specific ASM, so we can't use it on some systems, so we fall back to hyper-tls there.

Resolves #10 