### PR TITLE
Add methods for better traversal of the API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ web-sys = { version = "0.3.32", features = ["Response", "Window", "RequestInit",
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["io-std", "macros"] }
+anyhow = "1.0.25"

--- a/README.md
+++ b/README.md
@@ -15,27 +15,38 @@ supported.
 let client = Client::new();
 
 // Search for a runner.
-let runners = runner::search(&client, "cryze").await.unwrap();
-let runner = runners.first().unwrap();
-let runner_name = &*runner.name;
-assert_eq!(runner_name, "cryze92");
+let runner = Runner::search(&client, "cryze")
+    .await?
+    .into_iter()
+    .next()
+    .context("There is no runner with that name")?;
+
+assert_eq!(&*runner.name, "cryze92");
 
 // Get the PBs for the runner.
-let runner_pbs = runner::get_pbs(&client, runner_name).await.unwrap();
-let first_pb = &*runner_pbs.first().unwrap();
+let first_pb = runner.pbs(&client)
+    .await?
+    .into_iter()
+    .next()
+    .context("This runner doesn't have any PBs")?;
 
 // Get the game for the PB.
-let pb_game = first_pb.game.as_ref().unwrap();
-let pb_game_shortname = pb_game.shortname.as_ref().unwrap();
-assert_eq!(pb_game_shortname.as_ref(), "tww");
+let game = first_pb.game.context("There is no game for the PB")?;
+
+assert_eq!(&*game.name, "The Legend of Zelda: The Wind Waker");
 
 // Get the categories for the game.
-let game_categories = game::get_categories(&client, pb_game_shortname).await.unwrap();
+let categories = game.categories(&client).await?;
 
 // Get the runs for the Any% category.
-let any_percent = game_categories.iter().find(|category| &*category.name == "Any%").unwrap();
-let any_percent_runs = category::get_runs(&client, &any_percent.id).await.unwrap();
-assert!(!any_percent_runs.is_empty());
+let runs = categories
+    .iter()
+    .find(|category| &*category.name == "Any%")
+    .context("Couldn't find category")?
+    .runs(&client)
+    .await?;
+
+assert!(!runs.is_empty());
 ```
 
 ## License

--- a/src/category.rs
+++ b/src/category.rs
@@ -12,6 +12,23 @@ use crate::{
 use http::Request;
 use url::Url;
 
+impl Category {
+    /// Gets a Category.
+    pub async fn get(client: &Client, id: &str) -> Result<Self, Error> {
+        self::get(client, id).await
+    }
+
+    /// Gets the Runners that belong to the Category.
+    pub async fn runners(&self, client: &Client) -> Result<Vec<Runner>, Error> {
+        get_runners(client, &self.id).await
+    }
+
+    /// Gets the Runs that belong to the Category.
+    pub async fn runs(&self, client: &Client) -> Result<Vec<Run>, Error> {
+        get_runs(client, &self.id).await
+    }
+}
+
 /// Gets a Category.
 pub async fn get(client: &Client, id: &str) -> Result<Category, Error> {
     let mut url = Url::parse("https://splits.io/api/v4/categories").unwrap();

--- a/src/platform/wasm.rs
+++ b/src/platform/wasm.rs
@@ -138,9 +138,4 @@ impl Client {
 
         Ok(response)
     }
-
-    // pub async fn open_websocket(&self, url: &str) {
-    //     // TODO: wss:// vs. https://
-    //     let ws = WebSocket::new(url).map_err(|error| ReceiveResponse { error })?;
-    // }
 }

--- a/src/race.rs
+++ b/src/race.rs
@@ -2,18 +2,128 @@
 //!
 //! [API Documentation](https://github.com/glacials/splits-io/blob/master/docs/api.md#race)
 
-use crate::platform::Body;
+use crate::platform::{recv_bytes, Body};
 use crate::{
     get_json, get_response,
     wrapper::{
         ContainsChatMessage, ContainsChatMessages, ContainsEntries, ContainsEntry, ContainsRace,
         ContainsRaces,
     },
-    ChatMessage, Client, Entry, Error, Race, Visibility,
+    Attachment, ChatMessage, Client, Download, Entry, Error, Race, Visibility,
 };
 use http::{header::CONTENT_TYPE, Request};
+use snafu::ResultExt;
+use std::ops::Deref;
 use url::Url;
 use uuid::Uuid;
+
+impl Race {
+    /// Gets all the currently active Races on Splits.io.
+    pub async fn get_active(client: &Client) -> Result<Vec<Race>, Error> {
+        self::get_active(client).await
+    }
+
+    /// Gets a Race by its ID.
+    pub async fn get(client: &Client, id: Uuid) -> Result<Race, Error> {
+        self::get(client, id).await
+    }
+
+    /// Creates a new Race.
+    pub async fn create(client: &Client, settings: Settings<'_>) -> Result<Race, Error> {
+        self::create(client, settings).await
+    }
+
+    /// Updates the Race.
+    pub async fn update(
+        &self,
+        client: &Client,
+        settings: UpdateSettings<'_>,
+    ) -> Result<Race, Error> {
+        self::update(client, self.id, settings).await
+    }
+
+    /// Gets all of the entries for the Race.
+    pub async fn entries(&self, client: &Client) -> Result<Vec<Entry>, Error> {
+        self::get_entries(client, self.id).await
+    }
+
+    /// Gets the entry in the Race that is associated with the current user.
+    pub async fn my_entry(&self, client: &Client) -> Result<Entry, Error> {
+        self::get_entry(client, self.id).await
+    }
+
+    /// Joins the Race for the given entry.
+    pub async fn join(
+        &self,
+        client: &Client,
+        join_as: JoinAs<'_>,
+        join_token: Option<&str>,
+    ) -> Result<Entry, Error> {
+        self::join(client, self.id, join_as, join_token).await
+    }
+
+    /// Leaves the Race for the given entry.
+    pub async fn leave(&self, client: &Client, entry_id: Uuid) -> Result<(), Error> {
+        self::leave(client, self.id, entry_id).await
+    }
+
+    /// Declares the given entry as ready for the Race.
+    pub async fn ready_up(&self, client: &Client, entry_id: Uuid) -> Result<Entry, Error> {
+        self::ready_up(client, self.id, entry_id).await
+    }
+
+    /// Undoes a ready for the given entry in th Race.
+    pub async fn unready(&self, client: &Client, entry_id: Uuid) -> Result<Entry, Error> {
+        self::unready(client, self.id, entry_id).await
+    }
+
+    /// Finishes the Race for the given entry.
+    pub async fn finish(&self, client: &Client, entry_id: Uuid) -> Result<Entry, Error> {
+        self::finish(client, self.id, entry_id).await
+    }
+
+    /// Undoes a finish for the given entry in the Race.
+    pub async fn undo_finish(&self, client: &Client, entry_id: Uuid) -> Result<Entry, Error> {
+        self::undo_finish(client, self.id, entry_id).await
+    }
+
+    /// Forfeits the Race for the given entry.
+    pub async fn forfeit(&self, client: &Client, entry_id: Uuid) -> Result<Entry, Error> {
+        self::forfeit(client, self.id, entry_id).await
+    }
+
+    /// Undoes a forfeit for the given entry in the Race.
+    pub async fn undo_forfeit(&self, client: &Client, entry_id: Uuid) -> Result<Entry, Error> {
+        self::undo_forfeit(client, self.id, entry_id).await
+    }
+
+    /// Gets all of the chat messages for the Race.
+    pub async fn chat_messages(&self, client: &Client) -> Result<Vec<ChatMessage>, Error> {
+        self::get_chat(client, self.id).await
+    }
+
+    /// Sends a message in the chat for the Race.
+    pub async fn send_chat_message(
+        &self,
+        client: &Client,
+        message: &str,
+    ) -> Result<ChatMessage, Error> {
+        self::send_chat_message(client, self.id, message).await
+    }
+}
+
+impl Attachment {
+    /// Downloads the attachment.
+    pub async fn download(&self, client: &Client) -> Result<impl Deref<Target = [u8]>, Error> {
+        let response = get_response(
+            client,
+            Request::get(&*self.url).body(Body::empty()).unwrap(),
+        )
+        .await?;
+
+        recv_bytes(response.into_body()).await.context(Download)
+    }
+}
 
 /// Gets all the currently active Races on Splits.io.
 pub async fn get_active(client: &Client) -> Result<Vec<Race>, Error> {
@@ -28,9 +138,9 @@ pub async fn get_active(client: &Client) -> Result<Vec<Race>, Error> {
     Ok(races)
 }
 
-// TODO: get_all
+// FIXME: get_all
 
-/// Gets a Race.
+/// Gets a Race by its ID.
 pub async fn get(client: &Client, id: Uuid) -> Result<Race, Error> {
     let mut url = Url::parse("https://splits.io/api/v4/races").unwrap();
     url.path_segments_mut()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -15,6 +15,43 @@ use crate::{
 use http::Request;
 use url::Url;
 
+impl Runner {
+    /// Searches for a Runner based on the name of the runner.
+    pub async fn search(client: &Client, name: &str) -> Result<Vec<Runner>, Error> {
+        self::search(client, name).await
+    }
+
+    /// Gets the Runner that is associated with the current user.
+    pub async fn myself(client: &Client) -> Result<Runner, Error> {
+        self::myself(client).await
+    }
+
+    /// Gets a Runner based on the name of the runner.
+    pub async fn get(client: &Client, name: &str) -> Result<Runner, Error> {
+        self::get(client, name).await
+    }
+
+    /// Gets the Runs that are associated with the Runner.
+    pub async fn runs(&self, client: &Client) -> Result<Vec<Run>, Error> {
+        get_runs(client, &self.name).await
+    }
+
+    /// Gets the personal best Runs that are associated with the Runner.
+    pub async fn pbs(&self, client: &Client) -> Result<Vec<Run>, Error> {
+        get_pbs(client, &self.name).await
+    }
+
+    /// Gets the Games that are associated with the Runner.
+    pub async fn games(&self, client: &Client) -> Result<Vec<Game>, Error> {
+        get_games(client, &self.name).await
+    }
+
+    /// Gets the Categories that are associated with the Runner.
+    pub async fn categories(&self, client: &Client) -> Result<Vec<Category>, Error> {
+        get_categories(client, &self.name).await
+    }
+}
+
 /// Searches for a Runner based on the name of the runner.
 pub async fn search(client: &Client, name: &str) -> Result<Vec<Runner>, Error> {
     let mut url = Url::parse("https://splits.io/api/v4/runners").unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,68 @@
-use splits_io_api::{run, Client};
+use anyhow::Context;
+use splits_io_api::{Client, Run, Runner};
+
+macro_rules! test {
+    ($($t:tt)*) => {
+        let res: Result<(), anyhow::Error> = async {
+            {
+                $($t)*
+            }
+            Ok(())
+        }
+            .await;
+        res.unwrap();
+    };
+}
 
 #[tokio::test]
 async fn can_query_run() {
-    let client = Client::new();
-    let run = run::get(&client, "4cg", false).await.unwrap();
-    assert_eq!(&*run.game.unwrap().name, "Portal");
-    assert_eq!(&*run.category.unwrap().name, "Inbounds");
-    assert_eq!(run.attempts, Some(14));
+    test! {
+        let client = Client::new();
+        let run = Run::get(&client, "4cg", false).await?;
+        assert_eq!(&*run.game.context("No game")?.name, "Portal");
+        assert_eq!(&*run.category.context("No category")?.name, "Inbounds");
+        assert_eq!(run.attempts, Some(14));
+    }
+}
+
+#[tokio::test]
+async fn the_example_actually_works() {
+    test! {
+        // Create a Splits.io API client.
+        let client = Client::new();
+
+        // Search for a runner.
+        let runner = Runner::search(&client, "cryze")
+            .await?
+            .into_iter()
+            .next()
+            .context("There is no runner with that name")?;
+
+        assert_eq!(&*runner.name, "cryze92");
+
+        // Get the PBs for the runner.
+        let first_pb = runner.pbs(&client)
+            .await?
+            .into_iter()
+            .next()
+            .context("This runner doesn't have any PBs")?;
+
+        // Get the game for the PB.
+        let game = first_pb.game.context("There is no game for the PB")?;
+
+        assert_eq!(&*game.name, "The Legend of Zelda: The Wind Waker");
+
+        // Get the categories for the game.
+        let categories = game.categories(&client).await?;
+
+        // Get the runs for the Any% category.
+        let runs = categories
+            .iter()
+            .find(|category| &*category.name == "Any%")
+            .context("Couldn't find category")?
+            .runs(&client)
+            .await?;
+
+        assert!(!runs.is_empty());
+    }
 }


### PR DESCRIPTION
This also significantly simplifies the example. The previous API is left untouched. This is therefore not a breaking change.

Resolves #14 