### PR TITLE
Update `hyper-rustls` and fix lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ url = "2.1.0"
 uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1", "http2"] }
+hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http2"] }
 
 [target.'cfg(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))'.dependencies]
-hyper-rustls = "0.23.0"
+hyper-rustls = { version = "0.23.0", default-features = false, features = ["native-tokio", "http2", "tls12", "logging"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))))'.dependencies]
 hyper-tls = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "splits-io-api"
 version = "0.2.0"
 authors = ["Christopher Serr <christopher.serr@gmail.com>"]
-edition = "2018"
+edition = "2021"
 documentation = "https://docs.rs/splits-io-api/"
 repository = "https://github.com/LiveSplit/splits-io-api"
 license = "Apache-2.0/MIT"
@@ -31,7 +31,7 @@ uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http1", "http2"] }
 
 [target.'cfg(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))'.dependencies]
-hyper-rustls = "0.22.0"
+hyper-rustls = "0.23.0"
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))))'.dependencies]
 hyper-tls = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { version = "0.8.1", default-features = false, features = ["serde"] }
 hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http2"] }
 
 [target.'cfg(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))'.dependencies]
-hyper-rustls = { version = "0.23.0", default-features = false, features = ["native-tokio", "http2", "tls12", "logging"] }
+hyper-rustls = { version = "0.23.0", default-features = false, features = ["native-tokio", "http2", "tls12"] }
 
 [target.'cfg(all(not(target_arch = "wasm32"), not(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm", target_arch = "aarch64")))))'.dependencies]
 hyper-tls = "0.5.0"

--- a/src/game.rs
+++ b/src/game.rs
@@ -28,7 +28,7 @@ impl Game {
     pub async fn categories(&self, client: &Client) -> Result<Vec<Category>, Error> {
         get_categories(
             client,
-            &self.shortname.as_ref().context(UnidentifiableResource)?,
+            self.shortname.as_ref().context(UnidentifiableResource)?,
         )
         .await
     }
@@ -37,7 +37,7 @@ impl Game {
     pub async fn runs(&self, client: &Client) -> Result<Vec<Run>, Error> {
         get_runs(
             client,
-            &self.shortname.as_ref().context(UnidentifiableResource)?,
+            self.shortname.as_ref().context(UnidentifiableResource)?,
         )
         .await
     }
@@ -46,7 +46,7 @@ impl Game {
     pub async fn runners(&self, client: &Client) -> Result<Vec<Runner>, Error> {
         get_runners(
             client,
-            &self.shortname.as_ref().context(UnidentifiableResource)?,
+            self.shortname.as_ref().context(UnidentifiableResource)?,
         )
         .await
     }

--- a/src/platform/native.rs
+++ b/src/platform/native.rs
@@ -51,7 +51,7 @@ impl Client {
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_only()
-            .enable_http1()
+            .enable_http2()
             .build();
         #[cfg(not(all(
             any(target_os = "linux", target_family = "windows", target_os = "macos"),

--- a/src/platform/native.rs
+++ b/src/platform/native.rs
@@ -10,7 +10,7 @@ use hyper::body::Buf;
         target_arch = "aarch64",
     ),
 ))]
-use hyper_rustls::HttpsConnector;
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 #[cfg(not(all(
     any(target_os = "linux", target_family = "windows", target_os = "macos"),
     any(
@@ -48,7 +48,11 @@ impl Client {
                 target_arch = "aarch64",
             ),
         ))]
-        let https = HttpsConnector::with_native_roots();
+        let https = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_only()
+            .enable_http1()
+            .build();
         #[cfg(not(all(
             any(target_os = "linux", target_family = "windows", target_os = "macos"),
             any(

--- a/src/run.rs
+++ b/src/run.rs
@@ -20,7 +20,7 @@ use url::Url;
 impl Run {
     /// Downloads the splits for the Run.
     pub async fn download(&self, client: &Client) -> Result<impl Deref<Target = [u8]>, Error> {
-        self::download(client, &self.id.as_ref().context(UnidentifiableResource)?).await
+        self::download(client, self.id.as_ref().context(UnidentifiableResource)?).await
     }
 
     /// Gets a Run.
@@ -46,7 +46,7 @@ impl Run {
         let mut url = Url::parse("https://splits.io").unwrap();
         url.path_segments_mut()
             .unwrap()
-            .push(&self.id.as_ref().context(UnidentifiableResource)?);
+            .push(self.id.as_ref().context(UnidentifiableResource)?);
         Ok(url)
     }
 }
@@ -223,5 +223,5 @@ fn write_key_and_value(w: &mut impl Write, key: &str, value: &str) {
         "------WebKitFormBoundarymfBzYhzpfnJqay4s\r\nContent-Disposition: form-data; name=\"{}\"\r\n\r\n{}\r\n",
         key, value,
     )
-    .unwrap()
+    .unwrap();
 }


### PR DESCRIPTION
hyper-rustls now has a builder type and the old `with_native_certs` is gone.
HTTP 2 (h2) is now disabled by default.