### PR TITLE
Remove the OS limit for `rustls` targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splits-io-api"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Christopher Serr <christopher.serr@gmail.com>"]
 edition = "2021"
 documentation = "https://docs.rs/splits-io-api/"
@@ -31,10 +31,10 @@ uuid = { version = "1.1.2", default-features = false, features = ["serde"] }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 hyper = { version = "0.14.1", default-features = false, features = ["tcp", "client", "http2"] }
 
-[target.'cfg(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "arm", target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64", target_arch = "loongarch64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"), all(target_arch = "powerpc", target_endian = "big"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "s390x")))'.dependencies]
+[target.'cfg(any(target_arch = "arm", target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64", target_arch = "loongarch64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"), all(target_arch = "powerpc", target_endian = "big"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "s390x"))'.dependencies]
 hyper-rustls = { version = "0.24.1", default-features = false, features = ["native-tokio", "http2", "tls12"] }
 
-[target.'cfg(all(not(target_family = "wasm"), not(all(any(target_os = "linux", target_family = "windows", target_os = "macos"), any(target_arch = "arm", target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64", target_arch = "loongarch64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"), all(target_arch = "powerpc", target_endian = "big"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "s390x")))))'.dependencies]
+[target.'cfg(all(not(target_family = "wasm"), not(any(target_arch = "arm", target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64", target_arch = "loongarch64", all(target_arch = "mips", target_endian = "little"), all(target_arch = "mips64", target_endian = "little"), all(target_arch = "powerpc", target_endian = "big"), target_arch = "powerpc64", target_arch = "riscv64", target_arch = "s390x"))))'.dependencies]
 hyper-tls = "0.5.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/src/platform/native.rs
+++ b/src/platform/native.rs
@@ -1,38 +1,32 @@
 use http::{Request, Response};
 use hyper::body::Buf;
 
-#[cfg(all(
-    any(target_os = "linux", target_family = "windows", target_os = "macos"),
-    any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "loongarch64",
-        all(target_arch = "mips", target_endian = "little"),
-        all(target_arch = "mips64", target_endian = "little"),
-        all(target_arch = "powerpc", target_endian = "big"),
-        target_arch = "powerpc64",
-        target_arch = "riscv64",
-        target_arch = "s390x",
-    ),
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "loongarch64",
+    all(target_arch = "mips", target_endian = "little"),
+    all(target_arch = "mips64", target_endian = "little"),
+    all(target_arch = "powerpc", target_endian = "big"),
+    target_arch = "powerpc64",
+    target_arch = "riscv64",
+    target_arch = "s390x",
 ))]
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
-#[cfg(not(all(
-    any(target_os = "linux", target_family = "windows", target_os = "macos"),
-    any(
-        target_arch = "arm",
-        target_arch = "aarch64",
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "loongarch64",
-        all(target_arch = "mips", target_endian = "little"),
-        all(target_arch = "mips64", target_endian = "little"),
-        all(target_arch = "powerpc", target_endian = "big"),
-        target_arch = "powerpc64",
-        target_arch = "riscv64",
-        target_arch = "s390x",
-    ),
+#[cfg(not(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "loongarch64",
+    all(target_arch = "mips", target_endian = "little"),
+    all(target_arch = "mips64", target_endian = "little"),
+    all(target_arch = "powerpc", target_endian = "big"),
+    target_arch = "powerpc64",
+    target_arch = "riscv64",
+    target_arch = "s390x",
 )))]
 use hyper_tls::HttpsConnector;
 use std::{io::Read, ops::Deref};
@@ -53,42 +47,36 @@ pub struct Client {
 
 impl Client {
     pub fn new() -> Self {
-        #[cfg(all(
-            any(target_os = "linux", target_family = "windows", target_os = "macos"),
-            any(
-                target_arch = "arm",
-                target_arch = "aarch64",
-                target_arch = "x86",
-                target_arch = "x86_64",
-                target_arch = "loongarch64",
-                all(target_arch = "mips", target_endian = "little"),
-                all(target_arch = "mips64", target_endian = "little"),
-                all(target_arch = "powerpc", target_endian = "big"),
-                target_arch = "powerpc64",
-                target_arch = "riscv64",
-                target_arch = "s390x",
-            ),
+        #[cfg(any(
+            target_arch = "arm",
+            target_arch = "aarch64",
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "loongarch64",
+            all(target_arch = "mips", target_endian = "little"),
+            all(target_arch = "mips64", target_endian = "little"),
+            all(target_arch = "powerpc", target_endian = "big"),
+            target_arch = "powerpc64",
+            target_arch = "riscv64",
+            target_arch = "s390x",
         ))]
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_only()
             .enable_http2()
             .build();
-        #[cfg(not(all(
-            any(target_os = "linux", target_family = "windows", target_os = "macos"),
-            any(
-                target_arch = "arm",
-                target_arch = "aarch64",
-                target_arch = "x86",
-                target_arch = "x86_64",
-                target_arch = "loongarch64",
-                all(target_arch = "mips", target_endian = "little"),
-                all(target_arch = "mips64", target_endian = "little"),
-                all(target_arch = "powerpc", target_endian = "big"),
-                target_arch = "powerpc64",
-                target_arch = "riscv64",
-                target_arch = "s390x",
-            ),
+        #[cfg(not(any(
+            target_arch = "arm",
+            target_arch = "aarch64",
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "loongarch64",
+            all(target_arch = "mips", target_endian = "little"),
+            all(target_arch = "mips64", target_endian = "little"),
+            all(target_arch = "powerpc", target_endian = "big"),
+            target_arch = "powerpc64",
+            target_arch = "riscv64",
+            target_arch = "s390x",
         )))]
         let https = HttpsConnector::new();
         let client = hyper::Client::builder().build::<_, hyper::Body>(https);


### PR DESCRIPTION
It doesn't make sense to limit the OS to Linux, macOS, and Windows because `rustls` supports more than that.